### PR TITLE
Fix Case-Insensitive Import Collision

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -24,7 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 

--- a/api/environment.go
+++ b/api/environment.go
@@ -17,8 +17,8 @@ package api
 import (
 	"errors"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/dghubble/sling"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/api/network.go
+++ b/api/network.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/dghubble/sling"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/api/requests.go
+++ b/api/requests.go
@@ -23,8 +23,8 @@ import (
 
 	"encoding/json"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/dghubble/sling"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/api/vm.go
+++ b/api/vm.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/dghubble/sling"
+	log "github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
I changed all instances of `github.com/Sirupsen/logrus` to
`github.com/sirupsen/logrus` because of the case-insensitive issue I
came accross.